### PR TITLE
Intial documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ See the [documentation](docs/enigma_xml.md) page.
 
 ## Other Resources
 
-Many of the tags in Enigma Xml correspond to classes and properties in the [Finale PDK Framework](https://pdk.finalelua.com/). To the extent these can be mapped to the Xml, that documentation is also maintained.
+Many of the tags in Enigma Xml correspond to classes and properties in the [Finale PDK Framework](https://pdk.finalelua.com/). To the extent these can be mapped to the Xml, those links into the PDK Framework documentation are also maintained.
 
-Another tool that may help decipher the format is the free [Enigma Text Dump](https://robertgpatterson.com/-fininfo/-downloads/download-free.html) plugin for Finale. It spits out a text file of all the data it can find in the document in a format similar to the old Enigma Text File format. Where they are known, the output includes references to the corresponding PDK Framework classes.
+Another tool that may help decipher the format is the free [Enigma Text Dump](https://robertgpatterson.com/-fininfo/-downloads/download-free.html) plugin for Finale. It spits out a text file of all the data it can find in the document in a format similar to the old Enigma Text File format. Where they are known, the output includes references to the corresponding PDK Framework class names.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+## Overview
+This small command line utility decompresses Finale `.musx` files and extracts the critical score data as an Enigma Xml file. (Extension `.enigmaxml`.) This is an xml file in Finale's internal enigma format.
+
+Finale `.musx` files are actually `gzip` archives of a directory with the following structure.
+
+```
+/META-INF
+    container.xml
+mimetype
+NotationMetadata.xml
+score.dat
+```
+
+The `denigma` utility extracts the `score.dat` as `<file-name>.enigmaxml` where `<file-name>` is the original `.musx` filename.
+
+## Enigma Xml Format
+
+There is no official documentation of the Enigma XML format. This utility is a tool to aid third parties in analyzing and documenting it. This repository also maintains documentation pages that describe what has been discovered so far.
+
+See the [documentation](docs/enigma_xml.md) page.
+
+## Other Resources
+
+Many of the tags in Enigma Xml correspond to classes and properties in the [Finale PDK Framework](https://pdk.finalelua.com/). To the extent these can be mapped to the Xml, that documentation is also maintained.
+
+Another tool that may help decipher the format is the free [Enigma Text Dump](https://robertgpatterson.com/-fininfo/-downloads/download-free.html) plugin for Finale. It spits out a text file of all the data it can find in the document in a format similar to the old Enigma Text File format. Where they are known, the output includes references to the corresponding PDK Framework classes.

--- a/docs/enigma_xml.md
+++ b/docs/enigma_xml.md
@@ -1,0 +1,85 @@
+# Enigma XML Format Documentation
+
+## Table of Contents
+- [Overview](#overview)
+- [Root Element](#root-element)
+- [Node Structure](#node-structure)
+- [Node Definitions](#node-definitions)
+  - [mappings](#mappings)
+  - [header](#header)
+  - [options](#options)
+  - [others](#others)
+  - [details](#details)
+  - [entries](#entries)
+  - [texts](#texts)
+
+## Overview
+Enigma Xml is the internal proprietary format that Finale uses to store score data.
+
+## Root Element
+The root element is `finale`. This element encapsulates the entire XML structure and includes two attributes.
+
+### Attributes
+- **version** (string): Indicates the version of Finale that created the document.
+- **xmlns** (string): Specifies the XML namespace for the document. The value appears always to be `"http://www.makemusic.com/2012/finale"`.
+
+## Node Structure
+
+The highest level nodes correspond to each of the major sections of an Enigma file.
+Items are identified with an Enigma concept called a `cmper`. Cmpers are 16-bit values internally in Finale. Some are signed and others are not. Some are always sequential and some are not. There is a pool of items called `others` that contain a single cmper and a pool of items called `details` that contain two cmpers, `cmper1` and `cmper2`. Cmpers are usually 1-based, but there are exceptions.
+
+Some data types allow for multiple instances of the same cmper or pair of cmpers. These are separated by zero-based incis.
+
+Additionally, the `text` pool calls its cmpers `numbers` but they function the same as cmpers.
+
+The `entry` pool specifies the notes, chords, and rests. Each entry is identified by an `entnum`. This internally to Finale is a signed 32-bit value. If a piece is so big that it would exceed `INT_MAX` entries, it becomes corrupted. However, a file is much more likely to run out of frames (which uses a 16-bit cmper) before it runs out of entry numbers. Running out of frames also corrupts the file.
+
+### Example
+```xml
+<finale version="27.4" xmlns="http://www.makemusic.com/2012/finale">
+    <mappings/>
+    <header/>
+    <options/>
+    <others/>
+    <details/>
+    <entries/>
+    <texts/>
+</finale>
+```
+
+## Node Definitions
+
+### mappings
+
+Documentation needed.
+
+### header
+
+Contains metadata about the file such as encoding information, locale information, creation and modification dates, and Finale version that created it.
+
+### options
+
+The nodes under `options` correspond to the Document Options. The classes of the PDK Framework ending in `Prefs` also represent the Document Options. Unfortunately there is not always a good mapping between `options` and the `Prefs` classes.
+
+### others
+
+This is the pool of data structures with a single `cmper`.
+
+- `measSpec` Cmpers are 1-based and sequential. Each ocurrence defines the next measure of music. See [`FCMeasure`](https://pdk.finalelua.com/class_f_c_measure.html).
+- `staffSpec` Cmpers are 1-based and may contains gaps. Each ocurrence defines a staff. The cmpers do not specifiy the score order. They typically follow the order that staves were added to the document. See [`FCStaff`](https://pdk.finalelua.com/class_f_c_measure.html).
+- `frameSpec` Cmpers are 1-based and there may be gaps. Each occurrence defines the entries in a layer of music in a measure on a staff. To get to the frame, look at the `gfhold` node of the staff/measure combo in the `details` pool. Note that the `startEntry` and `endEntry` values are entry numbers and point to start and end positions in a doubly-linked list. You cannot do math on the entry numbers and know anything about how many entries are in a frame.
+
+### details
+
+This is the pool of data structures with two cmpers, `cmper1` and `cmper2`.
+
+- `gfhold` `cmper` identifies the `staffSpec`. `cmper2` identifies the `measSpec`. See [`FCCellFrameHold`](https://pdk.finalelua.com/class_f_c_cell_frame_hold.html). Every staff/measure combo that contains either music or a clef change has one of these. Completely empty measures may not. The `framex` subnodes correspond to layers 1 thru 4.
+
+### entries
+
+This is the pool of entries. Each entry may either be a rest or contain 1-15 notes. If a rest is non-floating, it will also contain a "note" that specifies its position on the staff. Entries form a series of doubly-linked lists. If a `prev` or `next` attribute is `0`, that means the list ends there. The [`FCNoteEntry`](https://pdk.finalelua.com/class_f_c_note_entry.html) class more-or-less corresponds to this pool, though Finale plugins access them differently.
+
+
+### texts
+
+This pool corresponds to the [`FCRawText`](https://pdk.finalelua.com/class_f_c_raw_text.html) class. There are several different pools of raw text, each with its own `number` sequence. The sequence is 1-based and there can be gaps.


### PR DESCRIPTION
This is just a start. I made some assumption about how the utility is going to work. Feel free to let me know if I should correct them. (Or you can merge and then rewrite as you see fit.)

I also made a start on documenting the Enigma Xml format. Ultimately, I don't think `md` is the best tool for it. I wonder what tool the [MusicXml group](https://www.w3.org/2021/06/musicxml40/musicxml-reference/) used, because it is quite good. I'd love to see us migrate to that at some point.

I know you said you don't think the documentation of the format is in scope for this repo. But I hope you will let us park it here until a better place comes along.

Resolves #2.

